### PR TITLE
Fancy debugger (wip)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,3 +80,25 @@ task checkUpdateJson doLast {
 	}
 }
 project.tasks.test.dependsOn(checkUpdateJson)
+
+
+
+sourceSets {
+	debugger {
+		java {
+			srcDir 'src/debugger/java'
+		}
+		resources {
+			srcDir 'src/debugger/resources'
+		}
+	}
+}
+
+task debuggerJar(type: Jar, dependsOn: classes) {
+	classifier = 'debugger'
+	from sourceSets.debugger.allSource
+}
+
+artifacts {
+	archives debuggerJar
+}

--- a/src/debugger/java/me/fril/regeneration/debugger/DebugChannelTab.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/DebugChannelTab.java
@@ -1,29 +1,116 @@
 package me.fril.regeneration.debugger;
 
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.GridLayout;
+import java.io.PrintStream;
+
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
 
 import com.mojang.authlib.GameProfile;
 
+import me.fril.regeneration.debugger.util.TextAreaOutputStream;
+import me.fril.regeneration.util.TimerChannel;
+
 @SuppressWarnings("serial")
-public class DebugChannelTab extends JPanel {
+public class DebugChannelTab extends JPanel implements IDebugChannel {
 	
-	private final GameProfile user;
+	private final String name;
+	private final PrintStream console;
+	private final JPanel topPanel;
+	
+	private final JLabel lblTick;
+	private long currentRecordingTick;
 	
 	public DebugChannelTab(GameProfile gameProfile) {
-		user = gameProfile;
-		add(new JLabel(user.getName()));
+		name = gameProfile.getName();
+		
+		setLayout(new GridLayout(1, 1));
+		
+		JTextArea textArea = new JTextArea();
+		textArea.setEnabled(false);
+		textArea.setDisabledTextColor(Color.BLACK);
+		console = new PrintStream(new TextAreaOutputStream(textArea));
+		
+		
+		
+		topPanel = new JPanel();
+		{
+			lblTick = new JLabel("Current tick: ");
+			topPanel.add(lblTick);
+		}
+		
+		
+		JSplitPane splitPane = new JSplitPane();
+		splitPane.setOrientation(JSplitPane.VERTICAL_SPLIT);
+		splitPane.setRightComponent(textArea);
+		splitPane.setLeftComponent(topPanel);
+		splitPane.setDividerLocation(.75D);
+		add(splitPane);
 	}
+	
 	
 	@Override
 	public String getName() {
-		return user.getName();
+		return name;
+	}
+	
+	@Override
+	public PrintStream getConsole() {
+		return console;
+	}
+	
+	
+
+	@Override
+	public void updateCurrentTick(long tick) {
+		EventQueue.invokeLater(()->{
+			currentRecordingTick = tick;
+			lblTick.setText("Current tick: "+tick);
+		});
+	}
+	
+	@Override
+	public void notifyExecution(TimerChannel channel, long tick) { //TODO EventQueue proxy implementation?
+		EventQueue.invokeLater(()->{
+			console.println("EXECUTING "+channel+" at "+tick);
+			
+			if (tick != currentRecordingTick)
+				console.println("WARNING: reported tick "+tick+" does not match recording tick "+currentRecordingTick);
+		});
 	}
 
-	public IDebugChannel getChannel() {
-		return new IDebugChannel() {
+
+	@Override
+	public void notifySchedule(TimerChannel channel, long inTicks, long scheduledTick) {
+		EventQueue.invokeLater(()->{
+			console.println("SCHEDULED "+channel+" in "+inTicks+" ("+(inTicks/20F)+"s) at "+scheduledTick);
 			
-		};
+			if (scheduledTick - inTicks != currentRecordingTick)
+				console.println("WARNING: inTicks & shceduledTick don't add up with the current recording tick ("+scheduledTick+"-"+inTicks+" != "+currentRecordingTick+")");
+		});
+	}
+	
+	
+	@Override
+	public void notifyScheduleBlank(TimerChannel channel) {
+		EventQueue.invokeLater(()->{
+			console.println("SCHEDULED BLANK ON "+channel);
+		});
+	}
+
+
+	@Override
+	public void notifyCancel(TimerChannel channel, long inTicks, long scheduledTick) {
+		EventQueue.invokeLater(()->{
+			console.println("CANCELED "+channel+", was in "+inTicks+" ("+(inTicks/20F)+"s) at "+scheduledTick);
+			
+			if (scheduledTick - inTicks != currentRecordingTick)
+				console.println("WARNING: inTicks & shceduledTick don't add up with the current recording tick ("+scheduledTick+"-"+inTicks+" != "+currentRecordingTick+")");
+		});
 	}
 	
 }

--- a/src/debugger/java/me/fril/regeneration/debugger/DebugChannelTab.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/DebugChannelTab.java
@@ -55,7 +55,7 @@ public class DebugChannelTab extends JPanel implements IDebugChannel {
 	
 	@Override
 	public String getName() {
-		return name;
+		return name == null ? "Unknown (logging in...)" : name;
 	}
 	
 	@Override
@@ -70,6 +70,17 @@ public class DebugChannelTab extends JPanel implements IDebugChannel {
 		EventQueue.invokeLater(()->{
 			currentRecordingTick = tick;
 			lblTick.setText("Current tick: "+tick);
+			
+			if (name == null && capability.getPlayer().getGameProfile() != null) {
+				name = capability.getPlayer().getGameProfile().getName();
+				
+				JTabbedPane tabs = (JTabbedPane)getParent();
+				tabs.setTitleAt(tabs.getSelectedIndex(), name);
+			}
+			
+			for (Entry<TimerChannel, ScheduledTask> en : capability.getStateManager().getScheduler().getSchedule().entrySet()) {
+				timerLabels.get(en.getKey()).setText(en.getKey() + ": " + en.getValue());
+			}
 		});
 	}
 	
@@ -110,6 +121,14 @@ public class DebugChannelTab extends JPanel implements IDebugChannel {
 			
 			if (scheduledTick - inTicks != currentRecordingTick)
 				console.println("WARNING: inTicks & shceduledTick don't add up with the current recording tick ("+scheduledTick+"-"+inTicks+" != "+currentRecordingTick+")");
+		});
+	}
+
+
+	@Override
+	public void warn(String msg) {
+		EventQueue.invokeLater(()->{
+			console.println("WARNING: "+msg);
 		});
 	}
 	

--- a/src/debugger/java/me/fril/regeneration/debugger/DebugChannelTab.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/DebugChannelTab.java
@@ -2,6 +2,7 @@ package me.fril.regeneration.debugger;
 
 import java.awt.Color;
 import java.awt.EventQueue;
+import java.awt.Font;
 import java.awt.GridLayout;
 import java.io.PrintStream;
 import java.util.HashMap;
@@ -51,6 +52,7 @@ public class DebugChannelTab extends JPanel {
 		JPanel pnlTop = new JPanel();
 		{
 			lblTick = new JLabel("Current tick: ", SwingConstants.CENTER);
+			lblTick.setFont(new Font(lblTick.getFont().getFontName(), Font.PLAIN, 16));
 			
 			JPanel pnlTimers = new JPanel();
 			for (TimerChannel tc : TimerChannel.values()) {

--- a/src/debugger/java/me/fril/regeneration/debugger/DebugChannelTab.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/DebugChannelTab.java
@@ -1,0 +1,29 @@
+package me.fril.regeneration.debugger;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import com.mojang.authlib.GameProfile;
+
+@SuppressWarnings("serial")
+public class DebugChannelTab extends JPanel {
+	
+	private final GameProfile user;
+	
+	public DebugChannelTab(GameProfile gameProfile) {
+		user = gameProfile;
+		add(new JLabel(user.getName()));
+	}
+	
+	@Override
+	public String getName() {
+		return user.getName();
+	}
+
+	public IDebugChannel getChannel() {
+		return new IDebugChannel() {
+			
+		};
+	}
+	
+}

--- a/src/debugger/java/me/fril/regeneration/debugger/IDebugChannel.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/IDebugChannel.java
@@ -1,7 +1,21 @@
 package me.fril.regeneration.debugger;
 
+import java.io.PrintStream;
+
+import me.fril.regeneration.util.TimerChannel;
+
 public interface IDebugChannel {
 	
-	//TODO add report messages
+	//STUB add report messages
+	
+	void updateCurrentTick(long tick);
+	
+	void notifyExecution(TimerChannel channel, long tick);
+	void notifyCancel(TimerChannel channel, long inTicks, long scheduledTick);
+	
+	void notifyScheduleBlank(TimerChannel channel);
+	void notifySchedule(TimerChannel channel, long inTicks, long scheduledTick);
+	
+	PrintStream getConsole();
 	
 }

--- a/src/debugger/java/me/fril/regeneration/debugger/IDebugChannel.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/IDebugChannel.java
@@ -1,0 +1,7 @@
+package me.fril.regeneration.debugger;
+
+public interface IDebugChannel {
+	
+	//TODO add report messages
+	
+}

--- a/src/debugger/java/me/fril/regeneration/debugger/IDebugChannel.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/IDebugChannel.java
@@ -1,22 +1,16 @@
 package me.fril.regeneration.debugger;
 
-import java.io.PrintStream;
-
 import me.fril.regeneration.util.TimerChannel;
 
 public interface IDebugChannel {
-	
-	//STUB add report messages
 	
 	void updateCurrentTick(long tick);
 	
 	void notifyExecution(TimerChannel channel, long tick);
 	void notifyCancel(TimerChannel channel, long inTicks, long scheduledTick);
 	
-	void notifyScheduleBlank(TimerChannel channel);
 	void notifySchedule(TimerChannel channel, long inTicks, long scheduledTick);
-	
-	PrintStream getConsole();
+	void notifyScheduleBlank(TimerChannel channel);
 	
 	void warn(String msg);
 	

--- a/src/debugger/java/me/fril/regeneration/debugger/IDebugChannel.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/IDebugChannel.java
@@ -18,4 +18,6 @@ public interface IDebugChannel {
 	
 	PrintStream getConsole();
 	
+	void warn(String msg);
+	
 }

--- a/src/debugger/java/me/fril/regeneration/debugger/MainDebugger.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/MainDebugger.java
@@ -1,0 +1,67 @@
+package me.fril.regeneration.debugger;
+
+import java.awt.BorderLayout;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.border.EmptyBorder;
+
+import com.mojang.authlib.GameProfile;
+
+public class MainDebugger {
+	
+	private static final JFrame frame;
+	private static final JTabbedPane tabs;
+	private static final Map<GameProfile, DebugChannelTab> tabReg = new HashMap<>();
+	
+	static {
+		frame = new JFrame();
+		
+		JPanel contentPane = new JPanel();
+		contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
+		contentPane.setLayout(new BorderLayout(0, 0));
+		frame.setContentPane(contentPane);
+		
+		tabs = new JTabbedPane();
+		contentPane.add(tabs, BorderLayout.CENTER);
+		
+		
+		String optX = System.getProperty("debuggerX"),
+				optY = System.getProperty("debuggerY");
+		int dx = optX == null ? 0 : Integer.valueOf(optX),
+				dy = optY == null ? 0 : Integer.valueOf(optY);
+		frame.setLocationRelativeTo(null);
+		frame.setLocation(frame.getX()+dx, frame.getY()+dy);
+		
+		frame.setAutoRequestFocus(false);
+		frame.setSize(450, 300);
+		frame.setVisible(true);
+	}
+	
+	private MainDebugger() {}
+	
+	
+	public static IDebugChannel registerPlayer(GameProfile gameProfile) {
+		DebugChannelTab tab = new DebugChannelTab(gameProfile);
+		
+		tabs.add(tab.getName(), tab);
+		tabReg.put(gameProfile, tab);
+		
+		return tab.getChannel();
+	}
+
+
+	public static void unregisterPlayer(GameProfile gameProfile) {
+		tabs.remove(tabReg.get(gameProfile));
+		tabReg.remove(gameProfile);
+	}
+	
+	
+	public static void open() {
+		frame.setVisible(true);
+	}
+	
+}

--- a/src/debugger/java/me/fril/regeneration/debugger/RegenDebugger.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/RegenDebugger.java
@@ -7,18 +7,19 @@ import java.util.Map;
 import javax.swing.JFrame;
 import javax.swing.JTabbedPane;
 
-import com.mojang.authlib.GameProfile;
-
 import me.fril.regeneration.RegenerationMod;
+import me.fril.regeneration.common.capability.IRegeneration;
 
 public class RegenDebugger {
 	
 	private static final JFrame frame;
 	private static final JTabbedPane tabs;
-	private static final Map<GameProfile, DebugChannelTab> tabReg = new HashMap<>();
+	private static final Map<IRegeneration, DebugChannelTab> tabReg = new HashMap<>();
 	
 	static {
 		frame = new JFrame("Regeneration v"+RegenerationMod.VERSION+" DEBUGGER");
+		frame.setAutoRequestFocus(false);
+		frame.setSize(900, 600);
 		
 		tabs = new JTabbedPane();
 		frame.add(tabs, BorderLayout.CENTER);
@@ -30,30 +31,27 @@ public class RegenDebugger {
 		frame.setLocationRelativeTo(null);
 		frame.setLocation(frame.getX()+dx, frame.getY()+dy);
 		
-		frame.setAutoRequestFocus(false);
-		frame.setSize(450, 300);
 		frame.setVisible(true);
 	}
 	
 	private RegenDebugger() {}
 	
 	
-	public static IDebugChannel registerPlayer(GameProfile gameProfile) {
-		if (tabReg.containsKey(gameProfile))
-			return tabReg.get(gameProfile);
+	public static IDebugChannel registerPlayer(IRegeneration capability) {
+		if (tabReg.containsKey(capability))
+			return tabReg.get(capability);
 		
-		DebugChannelTab tab = new DebugChannelTab(gameProfile);
-		
+		DebugChannelTab tab = new DebugChannelTab(capability);
 		tabs.addTab(tab.getName(), tab);
-		tabReg.put(gameProfile, tab);
+		tabReg.put(capability, tab);
 		
 		return tab;
 	}
 
 
-	public static void unregisterPlayer(GameProfile gameProfile) {
-		tabs.remove(tabReg.get(gameProfile));
-		tabReg.remove(gameProfile);
+	public static void unregisterPlayer(IRegeneration capability) {
+		tabs.remove(tabReg.get(capability));
+		tabReg.remove(capability);
 	}
 	
 	

--- a/src/debugger/java/me/fril/regeneration/debugger/RegenDebugger.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/RegenDebugger.java
@@ -38,9 +38,9 @@ public class RegenDebugger {
 	private RegenDebugger() {}
 	
 	
-	public static IDebugChannel registerPlayer(IRegeneration capability) {
+	public static IDebugChannel newSession(IRegeneration capability) {
 		if (tabReg.containsKey(capability))
-			return tabReg.get(capability).getChannel();
+			throw new IllegalStateException("Tried to start session for a capability that was already registered");
 		
 		DebugChannelTab tab = new DebugChannelTab(capability);
 		EventQueue.invokeLater(()->tabs.addTab(tab.getName(), tab));
@@ -50,9 +50,7 @@ public class RegenDebugger {
 	
 	
 	public static void unregisterPlayer(IRegeneration capability) {
-		EventQueue.invokeLater(()->{
-			//TODO mark "finished" session
-		});
+		EventQueue.invokeLater(()->tabs.removeTabAt(tabs.indexOfTabComponent(tabReg.get(capability))));
 		tabReg.remove(capability);
 	}
 	

--- a/src/debugger/java/me/fril/regeneration/debugger/RegenDebugger.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/RegenDebugger.java
@@ -40,17 +40,19 @@ public class RegenDebugger {
 	
 	public static IDebugChannel registerPlayer(IRegeneration capability) {
 		if (tabReg.containsKey(capability))
-			return tabReg.get(capability);
+			return tabReg.get(capability).getChannel();
 		
 		DebugChannelTab tab = new DebugChannelTab(capability);
 		EventQueue.invokeLater(()->tabs.addTab(tab.getName(), tab));
 		tabReg.put(capability, tab);
-		return tab;
+		return tab.getChannel();
 	}
-
-
+	
+	
 	public static void unregisterPlayer(IRegeneration capability) {
-		EventQueue.invokeLater(()->tabs.remove(tabReg.get(capability)));
+		EventQueue.invokeLater(()->{
+			//TODO mark "finished" session
+		});
 		tabReg.remove(capability);
 	}
 	

--- a/src/debugger/java/me/fril/regeneration/debugger/RegenDebugger.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/RegenDebugger.java
@@ -5,29 +5,23 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.swing.JFrame;
-import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
-import javax.swing.border.EmptyBorder;
 
 import com.mojang.authlib.GameProfile;
 
-public class MainDebugger {
+import me.fril.regeneration.RegenerationMod;
+
+public class RegenDebugger {
 	
 	private static final JFrame frame;
 	private static final JTabbedPane tabs;
 	private static final Map<GameProfile, DebugChannelTab> tabReg = new HashMap<>();
 	
 	static {
-		frame = new JFrame();
-		
-		JPanel contentPane = new JPanel();
-		contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
-		contentPane.setLayout(new BorderLayout(0, 0));
-		frame.setContentPane(contentPane);
+		frame = new JFrame("Regeneration v"+RegenerationMod.VERSION+" DEBUGGER");
 		
 		tabs = new JTabbedPane();
-		contentPane.add(tabs, BorderLayout.CENTER);
-		
+		frame.add(tabs, BorderLayout.CENTER);
 		
 		String optX = System.getProperty("debuggerX"),
 				optY = System.getProperty("debuggerY");
@@ -41,16 +35,19 @@ public class MainDebugger {
 		frame.setVisible(true);
 	}
 	
-	private MainDebugger() {}
+	private RegenDebugger() {}
 	
 	
 	public static IDebugChannel registerPlayer(GameProfile gameProfile) {
+		if (tabReg.containsKey(gameProfile))
+			return tabReg.get(gameProfile);
+		
 		DebugChannelTab tab = new DebugChannelTab(gameProfile);
 		
-		tabs.add(tab.getName(), tab);
+		tabs.addTab(tab.getName(), tab);
 		tabReg.put(gameProfile, tab);
 		
-		return tab.getChannel();
+		return tab;
 	}
 
 

--- a/src/debugger/java/me/fril/regeneration/debugger/RegenDebugger.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/RegenDebugger.java
@@ -1,6 +1,7 @@
 package me.fril.regeneration.debugger;
 
 import java.awt.BorderLayout;
+import java.awt.EventQueue;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,7 +20,7 @@ public class RegenDebugger {
 	static {
 		frame = new JFrame("Regeneration v"+RegenerationMod.VERSION+" DEBUGGER");
 		frame.setAutoRequestFocus(false);
-		frame.setSize(900, 600);
+		frame.setSize(500, 560);
 		
 		tabs = new JTabbedPane();
 		frame.add(tabs, BorderLayout.CENTER);
@@ -42,15 +43,14 @@ public class RegenDebugger {
 			return tabReg.get(capability);
 		
 		DebugChannelTab tab = new DebugChannelTab(capability);
-		tabs.addTab(tab.getName(), tab);
+		EventQueue.invokeLater(()->tabs.addTab(tab.getName(), tab));
 		tabReg.put(capability, tab);
-		
 		return tab;
 	}
 
 
 	public static void unregisterPlayer(IRegeneration capability) {
-		tabs.remove(tabReg.get(capability));
+		EventQueue.invokeLater(()->tabs.remove(tabReg.get(capability)));
 		tabReg.remove(capability);
 	}
 	

--- a/src/debugger/java/me/fril/regeneration/debugger/util/EventQueueDebugChannelProxy.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/util/EventQueueDebugChannelProxy.java
@@ -1,0 +1,61 @@
+package me.fril.regeneration.debugger.util;
+
+import java.awt.EventQueue;
+
+import me.fril.regeneration.debugger.IDebugChannel;
+import me.fril.regeneration.util.TimerChannel;
+
+/** Delegates all methods to the {@link #target} using {@link EventQueue#invokeLater(Runnable)} */
+public class EventQueueDebugChannelProxy implements IDebugChannel {
+	
+	private final IDebugChannel target;
+	
+	public EventQueueDebugChannelProxy(IDebugChannel target) {
+		this.target = target;
+	}
+	
+	
+	
+	@Override
+	public void updateCurrentTick(long tick) {
+		EventQueue.invokeLater(()->{
+			target.updateCurrentTick(tick);
+		});
+	}
+
+	@Override
+	public void notifyExecution(TimerChannel channel, long tick) {
+		EventQueue.invokeLater(()->{
+			target.notifyExecution(channel, tick);
+		});
+	}
+
+	@Override
+	public void notifyCancel(TimerChannel channel, long inTicks, long scheduledTick) {
+		EventQueue.invokeLater(()->{
+			target.notifyCancel(channel, inTicks, scheduledTick);
+		});
+	}
+
+	@Override
+	public void notifySchedule(TimerChannel channel, long inTicks, long scheduledTick) {
+		EventQueue.invokeLater(()->{
+			target.notifySchedule(channel, inTicks, scheduledTick);
+		});
+	}
+
+	@Override
+	public void notifyScheduleBlank(TimerChannel channel) {
+		EventQueue.invokeLater(()->{
+			target.notifyScheduleBlank(channel);
+		});
+	}
+
+	@Override
+	public void warn(String msg) {
+		EventQueue.invokeLater(()->{
+			target.warn(msg);
+		});
+	}
+	
+}

--- a/src/debugger/java/me/fril/regeneration/debugger/util/TextAreaOutputStream.java
+++ b/src/debugger/java/me/fril/regeneration/debugger/util/TextAreaOutputStream.java
@@ -1,0 +1,20 @@
+package me.fril.regeneration.debugger.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.swing.JTextArea;
+
+public class TextAreaOutputStream extends OutputStream {
+	private JTextArea textArea;
+	
+	public TextAreaOutputStream(JTextArea textArea) {
+        this.textArea = textArea;
+    }
+	
+	@Override
+	public void write(int b) throws IOException {
+		textArea.append(String.valueOf((char) b));
+		textArea.setCaretPosition(textArea.getDocument().getLength());
+	}
+}

--- a/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
+++ b/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
@@ -106,7 +106,8 @@ public class CapabilityRegeneration implements IRegeneration {
 		nbt.setString("state", state.toString());
 		nbt.setInteger("regenerationsLeft", regenerationsLeft);
 		nbt.setTag("style", getStyle());
-		nbt.setTag("stateManager", stateManager.serializeNBT());
+		if (!player.world.isRemote)
+			nbt.setTag("stateManager", stateManager.serializeNBT());
 		return nbt;
 	}
 
@@ -118,8 +119,6 @@ public class CapabilityRegeneration implements IRegeneration {
 		
 		if (nbt.hasKey("stateManager"))
 			stateManager.deserializeNBT(nbt.getCompoundTag("stateManager"));
-		else if (!player.world.isRemote)
-			stateManager.reset();
 	}
 	
 	

--- a/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
+++ b/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
@@ -41,7 +41,7 @@ public class CapabilityRegeneration implements IRegeneration {
 	private IRegenType type = RegenTypes.FIERY;
 	
 	private RegenState state = RegenState.ALIVE;
-	private final RegenerationStateManager stateManager = new RegenerationStateManager();
+	private final RegenerationStateManager stateManager;
 	
 	private float primaryRed = 0.93f, primaryGreen = 0.61f, primaryBlue = 0.0f;
 	private float secondaryRed = 1f, secondaryGreen = 0.5f, secondaryBlue = 0.18f;
@@ -60,10 +60,15 @@ public class CapabilityRegeneration implements IRegeneration {
 	
 	public CapabilityRegeneration() {
 		this.player = null;
+		this.stateManager = null;
 	}
 	
 	public CapabilityRegeneration(EntityPlayer player) {
 		this.player = player;
+		if (!player.world.isRemote)
+			this.stateManager = new RegenerationStateManager();
+		else
+			this.stateManager = null;
 	}
 	
 	
@@ -231,7 +236,7 @@ public class CapabilityRegeneration implements IRegeneration {
 		//private IDebugChannel debugChannel;
 		
 		private RegenerationStateManager() {
-			this.scheduler = new Scheduler();
+			this.scheduler = new Scheduler(RegenDebugger.registerPlayer(CapabilityRegeneration.this));
 		}
 		
 		
@@ -289,9 +294,6 @@ public class CapabilityRegeneration implements IRegeneration {
 		private void tick() {
 			if (player.world.isRemote)
 				throw new IllegalStateException("Ticking state manager on the client");
-			
-			if (!scheduler.hasDebugChannel())
-				scheduler.setDebugChannel(RegenDebugger.registerPlayer(player.getGameProfile()));
 			
 			scheduler.tick();
 			

--- a/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
+++ b/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
@@ -235,7 +235,7 @@ public class CapabilityRegeneration implements IRegeneration {
 		//private IDebugChannel debugChannel;
 		
 		private RegenerationStateManager() {
-			this.scheduler = new Scheduler(RegenDebugger.registerPlayer(CapabilityRegeneration.this));
+			this.scheduler = new Scheduler(RegenDebugger.newSession(CapabilityRegeneration.this));
 		}
 		
 		

--- a/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
+++ b/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
@@ -297,8 +297,15 @@ public class CapabilityRegeneration implements IRegeneration {
 			if (player.world.isRemote)
 				throw new IllegalStateException("Ticking state manager on the client");
 			
+			if (debugChannel == null)
+				debugChannel = MainDebugger.registerPlayer(player.getGameProfile());
+			
 			scheduler.tick();
-			//System.out.println(scheduledCriticalDeath.ticksLeft());
+			
+			/*for (TimerChannel tc : TimerChannel.values()) {
+				System.out.println(tc + ": " + timers.get(tc).ticksLeft());
+			}
+			System.out.println();*/
 			
 			/*if (player.getHealth() < player.getMaxHealth()) { TODO actually regenerate health
 				player.setHealth(player.getHealth() + 1); NOW move to external event handler

--- a/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
+++ b/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
@@ -11,7 +11,7 @@ import me.fril.regeneration.RegenerationMod;
 import me.fril.regeneration.common.types.IRegenType;
 import me.fril.regeneration.common.types.RegenTypes;
 import me.fril.regeneration.debugger.IDebugChannel;
-import me.fril.regeneration.debugger.MainDebugger;
+import me.fril.regeneration.debugger.RegenDebugger;
 import me.fril.regeneration.network.MessageSynchroniseRegeneration;
 import me.fril.regeneration.network.NetworkHandler;
 import me.fril.regeneration.util.RegenState;
@@ -244,11 +244,8 @@ public class CapabilityRegeneration implements IRegeneration {
 			if (timers.get(channel).ticksLeft() >= 0)
 				throw new IllegalStateException("Overwriting scheduled action ("+channel+" scheduled in "+timers.get(channel).ticksLeft()+")");
 			
-			ScheduledTask task = inTicks >= 0 ? scheduler.scheduleInTicks(inTicks, callback) : scheduler.createBlankTask();
+			ScheduledTask task = inTicks >= 0 ? scheduler.schedule(inTicks, callback) : scheduler.createBlankTask();
 			timers.put(channel, task);
-			
-			/*System.out.println("SCHEDULING "+channel+" IN "+inTicks+"t ("+(inTicks/20F)+"s)"); TODO log via debug channel
-			if (inTicks < 0) System.out.println("\t(SCHEDULED BLANK)");*/
 			
 			return task;
 		}
@@ -315,7 +312,7 @@ public class CapabilityRegeneration implements IRegeneration {
 				throw new IllegalStateException("Ticking state manager on the client");
 			
 			if (debugChannel == null)
-				debugChannel = MainDebugger.registerPlayer(player.getGameProfile());
+				debugChannel = RegenDebugger.registerPlayer(player.getGameProfile());
 			
 			scheduler.tick();
 			

--- a/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
+++ b/src/main/java/me/fril/regeneration/common/capability/CapabilityRegeneration.java
@@ -431,6 +431,15 @@ public class CapabilityRegeneration implements IRegeneration {
 			scheduler.scheduleInTicks(TimerChannel.GRACE_GLOWING,        nbt.getLong(TimerChannel.GRACE_GLOWING.toString()),        this::startGlowing);
 			scheduler.scheduleInTicks(TimerChannel.GRACE_CRITICAL_DEATH, nbt.getLong(TimerChannel.GRACE_CRITICAL_DEATH.toString()), this::midSequenceKill);
 		}
+
+
+
+
+		@Override
+		@Deprecated
+		public Scheduler getScheduler() {
+			return scheduler;
+		}
 		
 	}
 	

--- a/src/main/java/me/fril/regeneration/common/capability/IRegenerationStateManager.java
+++ b/src/main/java/me/fril/regeneration/common/capability/IRegenerationStateManager.java
@@ -1,5 +1,6 @@
 package me.fril.regeneration.common.capability;
 
+import me.fril.regeneration.util.Scheduler;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.INBTSerializable;
 
@@ -7,5 +8,8 @@ public interface IRegenerationStateManager extends INBTSerializable<NBTTagCompou
 	
 	boolean onKilled();
 	void onPunchBlock();
+	
+	@Deprecated
+	Scheduler getScheduler();
 	
 }

--- a/src/main/java/me/fril/regeneration/common/commands/RegenDebugCommand.java
+++ b/src/main/java/me/fril/regeneration/common/commands/RegenDebugCommand.java
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
 
 import me.fril.regeneration.common.capability.CapabilityRegeneration;
 import me.fril.regeneration.common.capability.IRegeneration;
-import me.fril.regeneration.debugger.MainDebugger;
+import me.fril.regeneration.debugger.RegenDebugger;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
@@ -39,7 +39,7 @@ public class RegenDebugCommand extends CommandBase {
 				break;*/
 			
 			case "open":
-				MainDebugger.open();
+				RegenDebugger.open();
 				break;
 			
 			case "regen":

--- a/src/main/java/me/fril/regeneration/common/commands/RegenDebugCommand.java
+++ b/src/main/java/me/fril/regeneration/common/commands/RegenDebugCommand.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 
 import me.fril.regeneration.common.capability.CapabilityRegeneration;
 import me.fril.regeneration.common.capability.IRegeneration;
+import me.fril.regeneration.debugger.MainDebugger;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
@@ -37,6 +38,10 @@ public class RegenDebugCommand extends CommandBase {
 					notifyCommandListener(sender, this, "Solace ticks: "+cap.getSolaceTicks());
 				break;*/
 			
+			case "open":
+				MainDebugger.open();
+				break;
+			
 			case "regen":
 				if (amount > 0) {
 					int difference = amount - cap.getRegenerationsLeft();
@@ -64,7 +69,7 @@ public class RegenDebugCommand extends CommandBase {
 	@Override
 	public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos) {
 		if (args.length < 2)
-			return getListOfStringsMatchingLastWord(args, "solace", "regen");
+			return getListOfStringsMatchingLastWord(args, "solace", "regen", "open");
 		else
 			return Collections.emptyList();
 	}

--- a/src/main/java/me/fril/regeneration/handlers/RegenEventHandler.java
+++ b/src/main/java/me/fril/regeneration/handlers/RegenEventHandler.java
@@ -78,7 +78,7 @@ public class RegenEventHandler {
 	
 	@SubscribeEvent
 	public static void onPlayerLoggedOut(PlayerLoggedOutEvent event) {
-		RegenDebugger.unregisterPlayer(event.player.getGameProfile());
+		RegenDebugger.unregisterPlayer(CapabilityRegeneration.getForPlayer(event.player));
 	}
 	
 	

--- a/src/main/java/me/fril/regeneration/handlers/RegenEventHandler.java
+++ b/src/main/java/me/fril/regeneration/handlers/RegenEventHandler.java
@@ -4,6 +4,7 @@ import me.fril.regeneration.RegenConfig;
 import me.fril.regeneration.RegenerationMod;
 import me.fril.regeneration.common.capability.CapabilityRegeneration;
 import me.fril.regeneration.common.capability.RegenerationProvider;
+import me.fril.regeneration.debugger.MainDebugger;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
@@ -25,6 +26,7 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerChangedDimensionEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedOutEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerRespawnEvent;
 
 /**
@@ -72,6 +74,11 @@ public class RegenEventHandler {
 	@SubscribeEvent
 	public static void onPlayerLoggedIn(PlayerLoggedInEvent event) {
 		CapabilityRegeneration.getForPlayer(event.player).synchronise();
+	}
+	
+	@SubscribeEvent
+	public static void onPlayerLoggedOut(PlayerLoggedOutEvent event) {
+		MainDebugger.unregisterPlayer(event.player.getGameProfile());
 	}
 	
 	

--- a/src/main/java/me/fril/regeneration/handlers/RegenEventHandler.java
+++ b/src/main/java/me/fril/regeneration/handlers/RegenEventHandler.java
@@ -4,7 +4,7 @@ import me.fril.regeneration.RegenConfig;
 import me.fril.regeneration.RegenerationMod;
 import me.fril.regeneration.common.capability.CapabilityRegeneration;
 import me.fril.regeneration.common.capability.RegenerationProvider;
-import me.fril.regeneration.debugger.MainDebugger;
+import me.fril.regeneration.debugger.RegenDebugger;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
@@ -78,7 +78,7 @@ public class RegenEventHandler {
 	
 	@SubscribeEvent
 	public static void onPlayerLoggedOut(PlayerLoggedOutEvent event) {
-		MainDebugger.unregisterPlayer(event.player.getGameProfile());
+		RegenDebugger.unregisterPlayer(event.player.getGameProfile());
 	}
 	
 	

--- a/src/main/java/me/fril/regeneration/util/Scheduler.java
+++ b/src/main/java/me/fril/regeneration/util/Scheduler.java
@@ -14,7 +14,7 @@ public class Scheduler { //TODO document why we can't instiate it with a debug c
 	
 	private long currentTick = 0;
 	
-	public void setDebugChannel(IDebugChannel debugChannel) {
+	public Scheduler(IDebugChannel debugChannel) {
 		this.debugChannel = debugChannel;
 	}
 	
@@ -71,10 +71,6 @@ public class Scheduler { //TODO document why we can't instiate it with a debug c
 		return schedule.containsKey(channel) ? schedule.get(channel).ticksLeft() : -1;
 	}
 	
-	public boolean hasDebugChannel() {
-		return debugChannel != null;
-	}
-	
 	public void reset() {
 		currentTick = 0;
 		schedule.clear();
@@ -127,5 +123,5 @@ public class Scheduler { //TODO document why we can't instiate it with a debug c
 		}
 		
 	}
-
+	
 }

--- a/src/main/java/me/fril/regeneration/util/Scheduler.java
+++ b/src/main/java/me/fril/regeneration/util/Scheduler.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import me.fril.regeneration.debugger.IDebugChannel;
 
-public class Scheduler { //TODO document why we can't instiate it with a debug channel
+public class Scheduler {
 	
 	private final Map<TimerChannel, ScheduledTask> schedule = new ConcurrentHashMap<>();
 	private final IDebugChannel debugChannel;
@@ -109,14 +109,10 @@ public class Scheduler { //TODO document why we can't instiate it with a debug c
 		}
 		
 		public void cancel() {
-			if (canceled)
-				System.err.println("WARNING: Cancelling already canceled action"); //TODO debug channel
 			canceled = true;
 			
 			if (scheduledTick - Scheduler.this.currentTick > 0) //still running
 				Scheduler.this.schedule.remove(channel);
-			else
-				System.err.println("WARNING: Cancelling already completed action"); //TODO debug channel
 		}
 		
 		public long ticksLeft() {

--- a/src/main/java/me/fril/regeneration/util/Scheduler.java
+++ b/src/main/java/me/fril/regeneration/util/Scheduler.java
@@ -22,11 +22,7 @@ public class Scheduler {
 		}
 	}
 	
-	public ScheduledTask scheduleInSeconds(long inSeconds, Runnable callback) {
-		return scheduleInTicks(inSeconds * 20, callback);
-	}
-	
-	public ScheduledTask scheduleInTicks(long inTicks, Runnable callback) {
+	public ScheduledTask schedule(long inTicks, Runnable callback) {
 		long scheduledTick = ticks + inTicks;
 		
 		List<ScheduledTask> list = schedule.containsKey(scheduledTick) ? schedule.get(scheduledTick) : new ArrayList<>();

--- a/src/main/java/me/fril/regeneration/util/Scheduler.java
+++ b/src/main/java/me/fril/regeneration/util/Scheduler.java
@@ -14,7 +14,7 @@ public class Scheduler {
 		ticks++;
 		
 		if (ticks % 20 == 0)
-			System.out.println("TICK "+ticks);
+			System.out.println("TICK "+ticks); //TODO debug channel
 		
 		if (schedule.containsKey(ticks)) {
 			schedule.get(ticks).forEach(r->r.run());
@@ -66,23 +66,17 @@ public class Scheduler {
 		
 		public void cancel() {
 			if (canceled)
-				System.err.println("WARNING: Cancelling already canceled action");
+				System.err.println("WARNING: Cancelling already canceled action"); //TODO debug channel
 			canceled = true;
 			
 			if (scheduledTick - Scheduler.this.ticks > 0)
 				Scheduler.this.schedule.get(scheduledTick).remove(this);
 			else
-				System.err.println("WARNING: Cancelling already completed action");
+				System.err.println("WARNING: Cancelling already completed action"); //TODO debug channel
 		}
 		
 		public long ticksLeft() {
 			return canceled ? -1 : scheduledTick - Scheduler.this.ticks;
-		}
-
-		/** @deprecated Meant for debugging! */
-		@Deprecated
-		public long scheduledTick() {
-			return scheduledTick;
 		}
 		
 	}
@@ -109,6 +103,12 @@ public class Scheduler {
 			return -1;
 		}
 		
+	}
+
+	
+	@Deprecated
+	public long currentTick() {
+		return ticks;
 	}
 
 }

--- a/src/main/java/me/fril/regeneration/util/Scheduler.java
+++ b/src/main/java/me/fril/regeneration/util/Scheduler.java
@@ -77,6 +77,12 @@ public class Scheduler { //TODO document why we can't instiate it with a debug c
 	}
 	
 	
+	@Deprecated
+	public Map<TimerChannel, ScheduledTask> getSchedule() {
+		return schedule;
+	}
+	
+	
 	
 	
 	
@@ -120,6 +126,10 @@ public class Scheduler { //TODO document why we can't instiate it with a debug c
 		@Override
 		public String toString() {
 			return "ScheduledTask[channel=" + channel + ", scheduledTick=" + scheduledTick + ", ticksLeft=" + ticksLeft() + ", canceled=" + canceled + "]";
+		}
+		
+		public String toStatusString() {
+			return "[scheduledTick=" + scheduledTick + ", ticksLeft=" + ticksLeft() + ", canceled=" + canceled + "]";
 		}
 		
 	}

--- a/src/main/java/me/fril/regeneration/util/TimerChannel.java
+++ b/src/main/java/me/fril/regeneration/util/TimerChannel.java
@@ -1,0 +1,9 @@
+package me.fril.regeneration.util;
+
+public enum TimerChannel {
+	REGENERATION_TRIGGER,
+	REGENERATION_FINISH,
+    GRACE_GLOWING,
+    GRACE_CRITICAL,
+    GRACE_CRITICAL_DEATH
+}

--- a/src/main/resources/assets/regeneration/lang/en_us.lang
+++ b/src/main/resources/assets/regeneration/lang/en_us.lang
@@ -55,7 +55,7 @@ config.regeneration.regeneration_kills_players=Regeneration kills players
 
 regeneration.damagesrc.regen_energy=&s was blasted by Regeneration Energy!
 
-regeneration.commands.debug.usage=<solace|regen> [amount]
+regeneration.commands.debug.usage=<solace|regen|open> [amount]
 
 regeneration.trait.current=Current Trait:
 regeneration.trait.messages.clumsy=Clumsy


### PR DESCRIPTION
### This is a work in progress, but I figured why not show it right now in case you don't like it at all

While I was debugging the critical phase for #43 I discovered that keeping track of all the timers using `System.out.println` and/or breakpoints is basically hell.
To make debugging easier I made a fancy GUI that logs all timer changes & lists the current status.
It opens when you first load a world (only when debugging of course), or use the `/regendebug open` command. There's a tab for each player *"session"*, when you die or reload another tab opens because of how minecraft works.
You can use JVM options (`-DdebuggerX` and `-DdebuggerY`) to move location where the debugger window opens, for example on a second screen (or at least not right in front of the game).

### Todo
- [ ] How does this behave on a dedicated or LAN server?
- [ ] Mark *"sessions"* that have finished (death, leaving world, ...)
- [ ] Improve the layout of the debugger
- [ ] Adding the actual switch for debug mode
- [ ] Cleanup & document (of course)


## Screenshot
![Debugger](https://i.imgur.com/wQmp57S.png)

#### (note: there are some fixes in this branch that apply to #43 too so if you don't like it I'll still have to merge some of it)