### PR TITLE
Make build.gradle properties easier to configure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,9 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '2.0.8'
+version = "${mod_version}"
 group = 'me.swirtzly' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = 'Regeneration-1.14.4'
+archivesBaseName = "${project.jar_name}-${minecraft_version}"
 
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 
@@ -34,7 +34,7 @@ repositories {
 }
 
 minecraft {
-    mappings channel: 'snapshot', version: '20190719-1.14.3'
+    mappings channel: "${mappings_type}", version: "${mappings_version}"
 
     runs {
         client {
@@ -94,8 +94,9 @@ minecraft {
 
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.14.4-28.2.23'
+    minecraft "net.minecraftforge:forge:${forge_version}"
     compile fg.deobf('com.gitlab.Spectre0987:TardisMod-1-14:master-SNAPSHOT')
+    //compile fg.deobf("com.gitlab.Spectre0987:TardisMod-1-14:${tm_tag}") //Use stable version of Tardis Mod
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,13 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
+# Mod Meta
+mod_version=2.0.8
+minecraft_version=1.14.4
+# Building
+jar_name=Regeneration
+forge_version=1.14.4-28.2.23
+mappings_version=20190719-1.14.3
+mappings_type=snapshot
+# Deps
+tm_tag=1.3.1-Release


### PR DESCRIPTION
This PR moves the configuration values in build.gradle to read from the gradle.properties file.

This would allow for easier configuration when building new versions of the mod, whilst preserving existing functionality.