### PR TITLE
Fixing Gradle config for contributors without access to private keys

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -27,7 +27,7 @@ unifiedPublishing {
             }
         }
 
-        var CURSE_API_KEY = project.findProperty("curseforge") ?: System.getenv("curseforge") ?: ""
+        var CURSE_API_KEY = project.findProperty("curseforge")?.apiKey ?: System.getenv("curseforge") ?: ""
         if (CURSE_API_KEY != "") {
             curseforge {
                 token = CURSE_API_KEY
@@ -36,7 +36,7 @@ unifiedPublishing {
             }
         }
 
-        var MODRINTH_TOKEN = project.findProperty("modrinth") ?: System.getenv("modrinth") ?: ""
+        var MODRINTH_TOKEN = project.findProperty("modrinth")?.apiKey ?: System.getenv("modrinth") ?: ""
         if (MODRINTH_TOKEN != "") {
             modrinth {
                 token = MODRINTH_TOKEN
@@ -73,7 +73,6 @@ dependencies {
     // Mod Menu
     modImplementation "curse.maven:modmenu-308702:3920481"
 
-    modImplementation "ignored:tardis_refined:1.0.0:fabric"
     modImplementation "dev.onyxstudios.cardinal-components-api:cardinal-components-base:${rootProject.cardinal_components_version}"
     modImplementation "dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${rootProject.cardinal_components_version}"
     modImplementation "dev.onyxstudios.cardinal-components-api:cardinal-components-world:${rootProject.cardinal_components_version}"

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -44,7 +44,7 @@ unifiedPublishing {
 
         }
 
-        var CURSE_API_KEY = project.findProperty("curseforge") ?: System.getenv("curseforge") ?: ""
+        var CURSE_API_KEY = project.findProperty("curseforge")?.apiKey ?: System.getenv("curseforge") ?: ""
         if (CURSE_API_KEY != "") {
             curseforge {
                 token = CURSE_API_KEY
@@ -53,7 +53,7 @@ unifiedPublishing {
             }
         }
 
-        var MODRINTH_TOKEN = project.findProperty("modrinth") ?: System.getenv("modrinth") ?: ""
+        var MODRINTH_TOKEN = project.findProperty("modrinth")?.apiKey ?: System.getenv("modrinth") ?: ""
         if (MODRINTH_TOKEN != "") {
             modrinth {
                 token = MODRINTH_TOKEN


### PR DESCRIPTION
## Context

When the API Key variable was being set at `build.gradle`, the empty check `API_KEY != ""` was not working because it was returning `"extension 'curseforge'"`. The problem has been fixed by using safe navigation to refer to the property `apiKey` directly.

## Images for reference

### The problem

![image](https://user-images.githubusercontent.com/58279735/223878302-e2292f59-4fc2-4c9f-a11c-6b737f47db1e.png)

### The return of `project.findProperty`

![image](https://user-images.githubusercontent.com/58279735/223878309-03e7170e-8ab1-4407-a5de-448929046510.png)

### After the fix

![image](https://user-images.githubusercontent.com/58279735/223878324-7e7200a8-f82e-4384-ac60-e371029c5cf9.png)
