### PR TITLE
Adding Toggle Trait key to 1.19.2 version

### DIFF
--- a/common/src/main/java/mc/craig/software/regen/client/RKeybinds.java
+++ b/common/src/main/java/mc/craig/software/regen/client/RKeybinds.java
@@ -2,6 +2,7 @@ package mc.craig.software.regen.client;
 
 import mc.craig.software.regen.client.screen.PreferencesScreen;
 import mc.craig.software.regen.network.messages.ForceRegenMessage;
+import mc.craig.software.regen.network.messages.ToggleTraitMessage;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import org.lwjgl.glfw.GLFW;
@@ -9,11 +10,17 @@ import org.lwjgl.glfw.GLFW;
 public class RKeybinds {
     public static KeyMapping FORCE_REGEN = new KeyMapping("Force Regeneration", GLFW.GLFW_KEY_Y, "Regeneration");
     public static KeyMapping REGEN_GUI = new KeyMapping("Open Preferences", GLFW.GLFW_KEY_F10, "Regeneration");
+    public static KeyMapping TOGGLE_TRAIT = new KeyMapping("Toggle Trait", GLFW.GLFW_KEY_RIGHT_ALT, "Regeneration");
 
     public static void tickKeybinds() {
         if (Minecraft.getInstance().level == null) return;
+
         if (FORCE_REGEN.consumeClick()) {
             new ForceRegenMessage().send();
+        }
+
+        if (TOGGLE_TRAIT.consumeClick()) {
+            new ToggleTraitMessage().send();
         }
 
         if (REGEN_GUI.consumeClick() && Minecraft.getInstance().screen == null) {

--- a/common/src/main/java/mc/craig/software/regen/client/screen/PreferencesScreen.java
+++ b/common/src/main/java/mc/craig/software/regen/client/screen/PreferencesScreen.java
@@ -129,7 +129,13 @@ public class PreferencesScreen extends Screen {
             GuiComponent.blit(matrixStack, Minecraft.getInstance().getWindow().getGuiScaledWidth() / 2 + (i * 10) - 10, Minecraft.getInstance().getWindow().getGuiScaledHeight() / 2 - 45, 52, 0, 9, 9, 256, 256);
         }
 
-        int color = Color.WHITE.getRGB();
+        int deactivatedColor = Color.RED.getRGB();
+        int activatedColor = Color.GREEN.getRGB();
+
+        boolean isTraitActivated = data.isTraitActive();
+
+        int color = isTraitActivated ? activatedColor : deactivatedColor;
+
         Component traitLang = data.getCurrentTrait().getTitle();
         IncarnationScreen.renderWidthScaledText(traitLang.getString(), matrixStack, font, width / 2 + 120 - 70, cy + 135, color, 100);
         Component traitLangDesc = data.getCurrentTrait().getDescription();

--- a/common/src/main/java/mc/craig/software/regen/common/regen/IRegen.java
+++ b/common/src/main/java/mc/craig/software/regen/common/regen/IRegen.java
@@ -94,6 +94,10 @@ public interface IRegen extends Serializable<CompoundTag> {
 
     void setHandState(Hand handState);
 
+    boolean isTraitActive();
+
+    void toggleTrait();
+
     TraitBase getCurrentTrait();
     void setCurrentTrait(TraitBase trait);
 

--- a/common/src/main/java/mc/craig/software/regen/common/regen/RegenerationData.java
+++ b/common/src/main/java/mc/craig/software/regen/common/regen/RegenerationData.java
@@ -50,10 +50,9 @@ public class RegenerationData implements IRegen {
     public AnimationState regen = new AnimationState();
     public AnimationState grace = new AnimationState();
     //Don't save to disk
-    private boolean didSetup = false;
-
+    private boolean didSetup = false, traitActive = true;
     private int regensLeft = 0, animationTicks = 0;
-    public boolean areHandsGlowing = false, traitActive = true, nextSkinTypeAlex = false, isAlex = false;
+    public boolean areHandsGlowing = false, nextSkinTypeAlex = false, isAlex = false;
 
     // ===== Skin Data =====
     private byte[] nextSkin = new byte[0], skinArray = new byte[0];
@@ -117,7 +116,7 @@ public class RegenerationData implements IRegen {
         AnimationState regenAnimState = getAnimationState(IRegen.RegenAnimation.REGEN);
         AnimationState graceAnimState = getAnimationState(IRegen.RegenAnimation.GRACE);
 
-        if (getCurrentTrait() != null) {
+        if (traitActive && getCurrentTrait() != null) {
             getCurrentTrait().tick(getLiving(), this);
         }
 
@@ -454,6 +453,14 @@ public class RegenerationData implements IRegen {
     @Override
     public void setHandState(IRegen.Hand handState) {
         this.handState = handState;
+    }
+
+    @Override
+    public boolean isTraitActive() { return traitActive; }
+
+    @Override
+    public void toggleTrait() {
+        this.traitActive = !traitActive;
     }
 
     @Override

--- a/common/src/main/java/mc/craig/software/regen/common/traits/trait/SpeedTrait.java
+++ b/common/src/main/java/mc/craig/software/regen/common/traits/trait/SpeedTrait.java
@@ -24,7 +24,7 @@ public class SpeedTrait extends TraitBase {
 
     @Override
     public void onRemoved(LivingEntity livingEntity, IRegen data) {
-
+        Objects.requireNonNull(livingEntity.getAttribute(Attributes.MOVEMENT_SPEED)).removeModifier(SPRINT_UUID);
     }
 
     @Override

--- a/common/src/main/java/mc/craig/software/regen/network/RegenNetwork.java
+++ b/common/src/main/java/mc/craig/software/regen/network/RegenNetwork.java
@@ -7,7 +7,7 @@ import net.minecraft.resources.ResourceLocation;
 public class RegenNetwork {
 
     public static final NetworkManager NETWORK = NetworkManager.create(new ResourceLocation(Regeneration.MOD_ID, "channel"));
-    public static MessageType TRANSITION_TYPE, UPLOAD_SKIN, SET_NEXT_SKIN, CHANGE_MODEL, UPDATE_POV, REMOVE_LOCAL_SKIN, PLAY_SFX, UPDATE_LOCAL_STATE, REMOVE_LOCAL_TIMELORD_SKIN, SYNC_CAP, CHANGE_SOUNDSCHEME, COLOR_CHANGE, FORCE_REGENERATION;
+    public static MessageType TOGGLE_TRAIT, TRANSITION_TYPE, UPLOAD_SKIN, SET_NEXT_SKIN, CHANGE_MODEL, UPDATE_POV, REMOVE_LOCAL_SKIN, PLAY_SFX, UPDATE_LOCAL_STATE, REMOVE_LOCAL_TIMELORD_SKIN, SYNC_CAP, CHANGE_SOUNDSCHEME, COLOR_CHANGE, FORCE_REGENERATION;
 
     public static void init() {
         UPDATE_POV = NETWORK.registerS2C("update_pov", POVMessage::new);
@@ -23,6 +23,7 @@ public class RegenNetwork {
         SET_NEXT_SKIN = NETWORK.registerC2S("set_next_skin", NextSkinMessage::new);
         UPLOAD_SKIN = NETWORK.registerC2S("upload_skin", SkinMessage::new);
         TRANSITION_TYPE = NETWORK.registerC2S("transition_type", TypeMessage::new);
+        TOGGLE_TRAIT = NETWORK.registerC2S("toggle_trait", ToggleTraitMessage::new);
     }
 
 }

--- a/common/src/main/java/mc/craig/software/regen/network/messages/ToggleTraitMessage.java
+++ b/common/src/main/java/mc/craig/software/regen/network/messages/ToggleTraitMessage.java
@@ -1,0 +1,45 @@
+package mc.craig.software.regen.network.messages;
+
+import mc.craig.software.regen.common.regen.RegenerationData;
+import mc.craig.software.regen.common.traits.trait.TraitBase;
+import mc.craig.software.regen.network.MessageC2S;
+import mc.craig.software.regen.network.MessageContext;
+import mc.craig.software.regen.network.MessageType;
+import mc.craig.software.regen.network.RegenNetwork;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.NotNull;
+
+public class ToggleTraitMessage extends MessageC2S {
+    public ToggleTraitMessage() {
+    }
+
+    public ToggleTraitMessage(FriendlyByteBuf buffer) {
+    }
+
+    public void handle(MessageContext context) {
+        ServerPlayer player = context.getPlayer();
+
+        RegenerationData.get(player).ifPresent(cap -> {
+            cap.toggleTrait();
+
+            TraitBase trait = cap.getCurrentTrait();
+
+            if (cap.isTraitActive()) {
+                trait.onAdded(player, cap);
+            } else {
+                trait.onRemoved(player, cap);
+            }
+            cap.syncToClients(null);
+        });
+    }
+
+    @NotNull
+    @Override
+    public MessageType getType() {
+        return RegenNetwork.TOGGLE_TRAIT;
+    }
+
+    public void toBytes(FriendlyByteBuf buf) {
+    }
+}

--- a/fabric/src/main/java/mc/craig/software/regen/fabric/RegenerationFabricClient.java
+++ b/fabric/src/main/java/mc/craig/software/regen/fabric/RegenerationFabricClient.java
@@ -55,6 +55,7 @@ public class RegenerationFabricClient implements ClientModInitializer {
         RModels.init();
         KeyBindingHelper.registerKeyBinding(RKeybinds.FORCE_REGEN);
         KeyBindingHelper.registerKeyBinding(RKeybinds.REGEN_GUI);
+        KeyBindingHelper.registerKeyBinding(RKeybinds.TOGGLE_TRAIT);
         register(PackType.CLIENT_RESOURCES, new SoundReverbListener());
         register(PackType.CLIENT_RESOURCES, new ArmorModelManager());
         ParticleFactoryRegistry.getInstance().register(RParticles.CONTAINER.get(), JarParticle.Factory::new);

--- a/fabric/src/main/java/mc/craig/software/regen/fabric/mixin/LivingEntityMixin.java
+++ b/fabric/src/main/java/mc/craig/software/regen/fabric/mixin/LivingEntityMixin.java
@@ -23,11 +23,11 @@ public class LivingEntityMixin {
     @Inject(at = @At("HEAD"), method = "knockback(DDD)V", cancellable = true)
     public void knockback(double strength, double x, double z, CallbackInfo ci) {
         LivingEntity livingEntity = (LivingEntity) (Object) this;
-         RegenerationData.get(livingEntity).ifPresent(regenerationData -> {
-             if(regenerationData.getCurrentTrait() == TraitRegistry.KNOCKBACK.get()){
-                 ci.cancel();
-             }
-         });
+        RegenerationData.get(livingEntity).ifPresent(regenerationData -> {
+            if (regenerationData.isTraitActive() && regenerationData.getCurrentTrait() == TraitRegistry.KNOCKBACK.get()) {
+                ci.cancel();
+            }
+        });
     }
 
     @Inject(at = @At("HEAD"), method = "hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z", cancellable = true)
@@ -39,7 +39,7 @@ public class LivingEntityMixin {
         if (source == RegenSources.REGEN_DMG_KILLED)
             return;
 
-        if (data.getCurrentTrait() == TraitRegistry.FIRE_RESISTANCE.get() && source.isFire() || data.getCurrentTrait() == TraitRegistry.ARROW_DODGE.get() && source.isProjectile()) {
+        if (data.isTraitActive() && (data.getCurrentTrait() == TraitRegistry.FIRE_RESISTANCE.get() && source.isFire() || data.getCurrentTrait() == TraitRegistry.ARROW_DODGE.get() && source.isProjectile())) {
             cir.setReturnValue(false);
         }
 

--- a/forge/src/main/java/mc/craig/software/regen/forge/handlers/CommonEvents.java
+++ b/forge/src/main/java/mc/craig/software/regen/forge/handlers/CommonEvents.java
@@ -49,12 +49,14 @@ public class CommonEvents {
                 PlayerUtil.sendMessage(livingEntity, Component.translatable(RMessages.POST_REDUCED_DAMAGE), true);
             }
 
-            if(data.getCurrentTrait() == TraitRegistry.FIRE_RESISTANCE.get() && event.getSource().isFire()){
-                event.setCanceled(true);
-            }
+            if (data.isTraitActive()) {
+                if (data.getCurrentTrait() == TraitRegistry.FIRE_RESISTANCE.get() && event.getSource().isFire()) {
+                    event.setCanceled(true);
+                }
 
-            if(data.getCurrentTrait() == TraitRegistry.ARROW_DODGE.get() && event.getSource().isProjectile()){
-                event.setCanceled(true);
+                if (data.getCurrentTrait() == TraitRegistry.ARROW_DODGE.get() && event.getSource().isProjectile()) {
+                    event.setCanceled(true);
+                }
             }
 
 
@@ -100,7 +102,20 @@ public class CommonEvents {
     @SubscribeEvent
     public static void onKnockback(LivingKnockBackEvent event) {
         LivingEntity livingEntity = event.getEntity();
-        RegenerationData.get(livingEntity).ifPresent((data) -> event.setCanceled(data.regenState() == RegenStates.REGENERATING));
+
+
+        RegenerationData.get(livingEntity).ifPresent((data) -> {
+            boolean isRegenerating = data.regenState() == RegenStates.REGENERATING;
+
+            if (!isRegenerating) {
+                if (data.isTraitActive() && data.getCurrentTrait() == TraitRegistry.KNOCKBACK.get()) {
+                    event.setCanceled(true);
+                    return;
+                }
+            }
+
+            event.setCanceled(isRegenerating);
+        });
     }
 
     @SubscribeEvent


### PR DESCRIPTION
- All traits can be toggled using a configurable key;
- The trait now is displayed in green for activated and red for deactivated;
- The KnockBack trait is now working properly on Forge;
- Tested both on Forge and Fabric.