### PR TITLE
Fixing dedicated server crash with Keybinds

### DIFF
--- a/forge/src/main/java/mc/craig/software/regen/client/event/ClientEvents.java
+++ b/forge/src/main/java/mc/craig/software/regen/client/event/ClientEvents.java
@@ -1,0 +1,17 @@
+package mc.craig.software.regen.client.event;
+
+import mc.craig.software.regen.Regeneration;
+import mc.craig.software.regen.client.RKeybinds;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = Regeneration.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+public class ClientEvents {
+    @SubscribeEvent
+    public static void keyMapping(RegisterKeyMappingsEvent event) {
+        event.register(RKeybinds.FORCE_REGEN);
+        event.register(RKeybinds.REGEN_GUI);
+    }
+}

--- a/forge/src/main/java/mc/craig/software/regen/forge/RegenerationForge.java
+++ b/forge/src/main/java/mc/craig/software/regen/forge/RegenerationForge.java
@@ -35,15 +35,9 @@ public class RegenerationForge {
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, RegenConfig.COMMON_SPEC);
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, RegenConfig.CLIENT_SPEC);
         modBus.addListener(this::clientSetup);
-        modBus.addListener(this::keyMapping);
         modBus.addListener(this::commonSetup);
         modBus.addListener(this::onAttributeAssign);
         modBus.addListener(this::onGatherData);
-    }
-
-    public void keyMapping(RegisterKeyMappingsEvent event) {
-        event.register(RKeybinds.FORCE_REGEN);
-        event.register(RKeybinds.REGEN_GUI);
     }
 
 


### PR DESCRIPTION
This PR fixes keybinds being registered on the wrong distance when running. (Results in a crash on dedicated server when not fixed)