### PR TITLE
Fixed REGENERATION_DATA capability not saving upon respawn

### DIFF
--- a/forge/src/main/java/mc/craig/software/regen/forge/handlers/CommonEvents.java
+++ b/forge/src/main/java/mc/craig/software/regen/forge/handlers/CommonEvents.java
@@ -3,6 +3,7 @@ package mc.craig.software.regen.forge.handlers;
 import mc.craig.software.regen.common.commands.RegenCommand;
 import mc.craig.software.regen.common.regen.IRegen;
 import mc.craig.software.regen.common.regen.RegenerationData;
+import mc.craig.software.regen.common.regen.forge.RegenerationDataImpl;
 import mc.craig.software.regen.common.regen.state.RegenStates;
 import mc.craig.software.regen.common.traits.TraitRegistry;
 import mc.craig.software.regen.config.RegenConfig;
@@ -15,6 +16,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.entity.living.*;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -65,6 +67,22 @@ public class CommonEvents {
                 event.setCanceled(true);
             }
         });
+    }
+
+    @SubscribeEvent
+    public static void playerCloneEvent(final PlayerEvent.Clone event) {
+        if(event.isWasDeath()){
+            Player player = event.getOriginal();
+            player.reviveCaps();
+
+            player.getCapability(RegenerationDataImpl.REGENERATION_DATA).ifPresent(cap ->
+                    event.getEntity().getCapability(RegenerationDataImpl.REGENERATION_DATA).ifPresent(newcap ->
+                            newcap.deserializeNBT(cap.serializeNBT())
+                    )
+            );
+
+            player.invalidateCaps();
+        }
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)


### PR DESCRIPTION
Regeneration Data capabilities wouldn't save upon death previously

(for some reason there was nothing that attempted to transfer the capability to the new entity lol)