### PR TITLE
Registering TOGGLE_TRAIT Keybind on Forge

### DIFF
--- a/forge/src/main/java/mc/craig/software/regen/client/event/ClientEvents.java
+++ b/forge/src/main/java/mc/craig/software/regen/client/event/ClientEvents.java
@@ -13,5 +13,6 @@ public class ClientEvents {
     public static void keyMapping(RegisterKeyMappingsEvent event) {
         event.register(RKeybinds.FORCE_REGEN);
         event.register(RKeybinds.REGEN_GUI);
+        event.register(RKeybinds.TOGGLE_TRAIT);
     }
 }


### PR DESCRIPTION
When toggling traits was ported to 1.19.2, the contributor forgot to register the keybind for toggling traits on Forge. Poor Forge not getting any attention unlike Fabric.

- This PR simply registers the keybind and makes Forge whole again.